### PR TITLE
fix: missing template specifier for std::mutex

### DIFF
--- a/wrapper/lld-c.cpp
+++ b/wrapper/lld-c.cpp
@@ -78,7 +78,7 @@ LldInvokeResult mun_lld_link(LldFlavor flavor, int argc, const char *const *argv
     }
 
     // LLD is not thread-safe at all, so we guard parallel invocation with a mutex
-    std::unique_lock lock(concurrencyMutex);
+    std::unique_lock<std::mutex> lock(concurrencyMutex);
     result.success = link(args, outputStream, errorStream, false, false);
 
     // Delete the global context and clear the global context pointer, so that it


### PR DESCRIPTION
Adds the `std::mutex` template specifier to the `std::unique_lock` call in `mun_lld_link` in order to fix C++ errors when trying to build `lld-rs v140.0.0`.

**Additional context**
We have noticed our docker container in our CI was no longer building successfully for the past 3 days due to the following error:
```
  cargo:warning=wrapper/lld-c.cpp: In function 'LldInvokeResult mun_lld_link(LldFlavor, int, const char* const*)':
  cargo:warning=wrapper/lld-c.cpp:81:22: error: missing template arguments before 'lock'
  cargo:warning=   81 |     std::unique_lock lock(concurrencyMutex);
  cargo:warning=      |                      ^~~~

  --- stderr


  error occurred in cc-rs: command did not execute successfully (status code exit status: 1): LC_ALL="C" "c++" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-std=c++17" "-I/usr/lib/llvm-14/include" "-std=c++14" "-fno-exceptions" "-D_GNU_SOURCE" "-D__STDC_CONSTANT_MACROS" "-D__STDC_FORMAT_MACROS" "-D__STDC_LIMIT_MACROS" "-o" "/dev/lld-rs/target/debug/build/lld_rs-05d4cd24dcdf0143/out/dce0d14135496489-lld-c.o" "-c" "wrapper/lld-c.cpp"
```

We have not made any changes to our container in the past 3 months and were unable to build `lld-rs` locally either, incurring the same error. Adding the specific template type fixes this build issue.